### PR TITLE
feat: remove dependence for @alifd/next

### DIFF
--- a/content/package.json
+++ b/content/package.json
@@ -27,9 +27,6 @@
     "postcss-loader": "^2.0.6",
     "postcss-calc": "^7.0.4"
   },
-  "dependencies": {
-    "{{library.npm}}": "~{{library.baseline}}"
-  },
   "peerDependencies": {
     "moment": "^2.22.1",
     "react": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alifd/next-theme-template",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "next theme template",
   "author": "no-repeat <chenpeng.mini@gmail.com>",
   "license": "ISC",


### PR DESCRIPTION
去掉了主题包中对@alifd/next基础组件的直接依赖
优势：
- 不强制安装基础组件的版本，业务项目中不会有安装多份next的风险（例如用户项目里引用了 @alife/theme-14/index.scss 同时又引用了 @alifd/next）

风险：
- 如果之前有用户仅引用了主题包（如@alife/theme-14/index.scss），没有引入@alifd/next，会有问题，构建不通过（需要用户手动升级主题包才会发生）
